### PR TITLE
Add MusicBrainz genre lookup

### DIFF
--- a/mp3_id3_processor/musicbrainz_client.py
+++ b/mp3_id3_processor/musicbrainz_client.py
@@ -1,0 +1,55 @@
+import musicbrainzngs
+from dataclasses import dataclass
+from typing import Optional
+import logging
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class MusicBrainzMetadata:
+    """Container for metadata retrieved from MusicBrainz."""
+    artist: Optional[str] = None
+    album: Optional[str] = None
+    track: Optional[str] = None
+    genre: Optional[str] = None
+    source: str = "musicbrainz"
+
+    def has_genre(self) -> bool:
+        """Check if genre information is available."""
+        return self.genre is not None and self.genre.strip() != ""
+
+class MusicBrainzClient:
+    """Simple client for querying MusicBrainz for genre information."""
+
+    def __init__(self, app_name: str = "mp3-id3-processor", app_version: str = "1.0", contact: Optional[str] = None):
+        """Initialize the client and set the user agent."""
+        self.app_name = app_name
+        self.app_version = app_version
+        self.contact = contact or ""
+        musicbrainzngs.set_useragent(self.app_name, self.app_version, self.contact)
+
+    def get_genre(self, artist: str, album: str, track: str) -> Optional[MusicBrainzMetadata]:
+        """Fetch genre for the given artist/album/track combination."""
+        if not (artist and album and track):
+            return None
+        try:
+            result = musicbrainzngs.search_recordings(artist=artist, release=album, recording=track, limit=1)
+            recordings = result.get("recording-list")
+            if recordings:
+                recording = recordings[0]
+                tag_list = recording.get("tag-list", [])
+                for tag in tag_list:
+                    if int(tag.get("count", 0)) > 0:
+                        name = tag.get("name")
+                        if name:
+                            return MusicBrainzMetadata(
+                                artist=artist,
+                                album=album,
+                                track=track,
+                                genre=name.capitalize(),
+                            )
+        except musicbrainzngs.WebServiceError as exc:
+            logger.warning(f"MusicBrainz error: {exc}")
+        except Exception as exc:
+            logger.debug(f"Unexpected MusicBrainz error: {exc}")
+        return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 mutagen>=1.47.0
 requests>=2.28.1
+musicbrainzngs>=0.7.1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -109,7 +109,8 @@ class TestMainFunction:
     @patch('mp3_id3_processor.main.ProcessingLogger')
     @patch('mp3_id3_processor.main.MetadataExtractor')
     @patch('mp3_id3_processor.main.AudioDBClient')
-    def test_main_successful_processing(self, mock_audiodb_client, mock_metadata_extractor,
+    @patch('mp3_id3_processor.main.MusicBrainzClient')
+    def test_main_successful_processing(self, mock_mb_client, mock_audiodb_client, mock_metadata_extractor,
                                       mock_logger_class, mock_processor_class,
                                       mock_scanner_class, mock_validate_dir,
                                       mock_config_class, mock_parse_args):
@@ -236,7 +237,8 @@ class TestMainFunction:
     @patch('mp3_id3_processor.main.ProcessingLogger')
     @patch('mp3_id3_processor.main.MetadataExtractor')
     @patch('mp3_id3_processor.main.AudioDBClient')
-    def test_main_dry_run_mode(self, mock_audiodb_client, mock_metadata_extractor, mock_logger_class, mock_processor_class,
+    @patch('mp3_id3_processor.main.MusicBrainzClient')
+    def test_main_dry_run_mode(self, mock_mb_client, mock_audiodb_client, mock_metadata_extractor, mock_logger_class, mock_processor_class,
                              mock_scanner_class, mock_validate_dir,
                              mock_config_class, mock_parse_args):
         """Test main function in dry-run mode."""

--- a/tests/test_musicbrainz_client.py
+++ b/tests/test_musicbrainz_client.py
@@ -1,0 +1,34 @@
+import unittest
+from unittest.mock import patch
+
+from mp3_id3_processor.musicbrainz_client import MusicBrainzClient, MusicBrainzMetadata
+
+class TestMusicBrainzClient(unittest.TestCase):
+    @patch('mp3_id3_processor.musicbrainz_client.musicbrainzngs.search_recordings')
+    def test_get_genre_success(self, mock_search):
+        mock_search.return_value = {
+            'recording-list': [
+                {'tag-list': [{'name': 'Rock', 'count': '2'}]}
+            ]
+        }
+        client = MusicBrainzClient()
+        metadata = client.get_genre('Artist', 'Album', 'Track')
+        self.assertIsInstance(metadata, MusicBrainzMetadata)
+        self.assertEqual(metadata.genre, 'Rock')
+
+    @patch('mp3_id3_processor.musicbrainz_client.musicbrainzngs.search_recordings')
+    def test_get_genre_no_result(self, mock_search):
+        mock_search.return_value = {'recording-list': []}
+        client = MusicBrainzClient()
+        metadata = client.get_genre('A', 'B', 'C')
+        self.assertIsNone(metadata)
+
+    @patch('mp3_id3_processor.musicbrainz_client.musicbrainzngs.search_recordings')
+    def test_get_genre_error(self, mock_search):
+        mock_search.side_effect = Exception('fail')
+        client = MusicBrainzClient()
+        metadata = client.get_genre('A', 'B', 'C')
+        self.assertIsNone(metadata)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- integrate MusicBrainz API via new `MusicBrainzClient`
- use MusicBrainz as fallback genre source in main program
- add dependency `musicbrainzngs`
- update unit tests and add tests for new client

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885292fd850832396c77e199c38234c