### PR TITLE
Add MusicBrainz year lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # MP3 ID3 Processor
 
-A simple command-line tool that automatically adds missing genre ID3 tag to MP3 files in your music collection without modifying existing metadata.
+A simple command-line tool that automatically adds missing genre and year ID3 tags to MP3 files in your music collection without modifying existing metadata.
 
 ## Features
 
 - **Safe and Non-destructive**: Preserves all existing ID3 tags and metadata
 - **Automatic Discovery**: Recursively scans your music directory for MP3 files
-- **API Integration**: Uses the MusicBrainz API to lookup missing genre information
+- **API Integration**: Uses the MusicBrainz API to lookup missing genre and year information
 - **Configurable Defaults**: Set custom default values for missing tags
 - **Comprehensive Logging**: Detailed progress reporting and error handling
 - **Dry Run Mode**: Preview changes before applying them
@@ -140,17 +140,18 @@ Create a JSON configuration file to customize default behavior:
 ## How It Works
 
 1. **Scanning**: Recursively scans the specified directory for MP3 files
-2. **Analysis**: Examines each MP3 file to identify missing genre tags
-3. **API Lookup**: Uses the MusicBrainz API to find missing genre information based on existing tags
+2. **Analysis**: Examines each MP3 file to identify missing genre and year tags
+3. **API Lookup**: Uses the MusicBrainz API to find missing genre and year information based on existing tags
 4. **Safe Modification**: Adds only missing tags while preserving all existing metadata
 5. **Reporting**: Provides detailed summary of all changes made
 
 ## API Integration
 
-The application uses the MusicBrainz API to lookup missing genre information:
+The application uses the MusicBrainz API to lookup missing genre and year information:
 
 - Searches recordings by artist, album, and track title
 - Returns the most popular genre tag found for the recording
+- Retrieves the release year when available
 
 ## Safety Features
 
@@ -167,8 +168,8 @@ The application uses the MusicBrainz API to lookup missing genre information:
 Starting MP3 ID3 processing...
 Found 150 MP3 files to process
 
-[1/150] song1.mp3: Added genre (Rock)
-[2/150] song2.mp3: Already had genre
+[1/150] song1.mp3: Added genre (Rock) and year (1999)
+[2/150] song2.mp3: Already had genre and year
 [3/150] song3.mp3: Added genre (Pop)
 [4/150] song4.mp3: Already has all tags
 ...
@@ -187,8 +188,8 @@ Processing completed successfully!
 ```
 DRY RUN MODE - No files will be modified
 --------------------------------------------------
-Would add genre to: song1.mp3 (genre: Rock)
-No changes for: song2.mp3 (already has genre)
+Would add genre and year to: song1.mp3 (genre: Rock, year: 1999)
+No changes for: song2.mp3 (already has genre and year)
 Would add genre to: song3.mp3 (genre: Pop)
 No changes for: song4.mp3 (already has all tags)
 ...
@@ -200,6 +201,7 @@ Total files found: 150
 Files that would be modified: 45
 Tags that would be added:
   genre: 25 files
+  year: 20 files
 ==================================================
 ```
 

--- a/mp3_id3_processor/musicbrainz_client.py
+++ b/mp3_id3_processor/musicbrainz_client.py
@@ -12,44 +12,88 @@ class MusicBrainzMetadata:
     album: Optional[str] = None
     track: Optional[str] = None
     genre: Optional[str] = None
+    year: Optional[str] = None
     source: str = "musicbrainz"
 
     def has_genre(self) -> bool:
         """Check if genre information is available."""
         return self.genre is not None and self.genre.strip() != ""
 
-class MusicBrainzClient:
-    """Simple client for querying MusicBrainz for genre information."""
+    def has_year(self) -> bool:
+        """Check if year information is available."""
+        return self.year is not None and self.year.strip() != ""
 
-    def __init__(self, app_name: str = "mp3-id3-processor", app_version: str = "1.0", contact: Optional[str] = None):
-        """Initialize the client and set the user agent."""
+class MusicBrainzClient:
+    """Simple client for querying MusicBrainz for metadata."""
+
+    def __init__(
+        self,
+        app_name: str = "mp3-id3-processor",
+        app_version: str = "1.0",
+        contact: Optional[str] = "https://example.com",
+    ):
+        """Initialize the client and configure request settings."""
         self.app_name = app_name
         self.app_version = app_version
-        self.contact = contact or ""
-        musicbrainzngs.set_useragent(self.app_name, self.app_version, self.contact)
+        self.contact = contact or "https://example.com"
 
-    def get_genre(self, artist: str, album: str, track: str) -> Optional[MusicBrainzMetadata]:
-        """Fetch genre for the given artist/album/track combination."""
+        musicbrainzngs.set_useragent(self.app_name, self.app_version, self.contact)
+        # Follow MusicBrainz guidelines: limit one request per second
+        musicbrainzngs.set_rate_limit(limit_or_interval=1.0, new_requests=1)
+
+    def get_metadata(
+        self, artist: str, album: str, track: str
+    ) -> Optional[MusicBrainzMetadata]:
+        """Fetch genre and year for the given artist/album/track."""
         if not (artist and album and track):
             return None
+
         try:
-            result = musicbrainzngs.search_recordings(artist=artist, release=album, recording=track, limit=1)
+            result = musicbrainzngs.search_recordings(
+                artist=artist,
+                release=album,
+                recording=track,
+                limit=1,
+                includes=["tags", "releases"],
+            )
             recordings = result.get("recording-list")
-            if recordings:
-                recording = recordings[0]
-                tag_list = recording.get("tag-list", [])
-                for tag in tag_list:
-                    if int(tag.get("count", 0)) > 0:
-                        name = tag.get("name")
-                        if name:
-                            return MusicBrainzMetadata(
-                                artist=artist,
-                                album=album,
-                                track=track,
-                                genre=name.capitalize(),
-                            )
+            if not recordings:
+                return None
+
+            recording = recordings[0]
+
+            genre = None
+            tag_list = recording.get("tag-list", [])
+            for tag in tag_list:
+                if int(tag.get("count", 0)) > 0:
+                    name = tag.get("name")
+                    if name:
+                        genre = name.capitalize()
+                        break
+
+            year = None
+            release_list = recording.get("release-list", [])
+            if release_list:
+                date_str = release_list[0].get("date")
+                if date_str and len(date_str) >= 4 and date_str[:4].isdigit():
+                    year = date_str[:4]
+
+            return MusicBrainzMetadata(
+                artist=artist,
+                album=album,
+                track=track,
+                genre=genre,
+                year=year,
+            )
         except musicbrainzngs.WebServiceError as exc:
             logger.warning(f"MusicBrainz error: {exc}")
         except Exception as exc:
             logger.debug(f"Unexpected MusicBrainz error: {exc}")
+        return None
+
+    def get_genre(self, artist: str, album: str, track: str) -> Optional[MusicBrainzMetadata]:
+        """Compatibility wrapper returning only genre information."""
+        metadata = self.get_metadata(artist, album, track)
+        if metadata and metadata.genre:
+            return metadata
         return None

--- a/mp3_id3_processor/processor.py
+++ b/mp3_id3_processor/processor.py
@@ -27,7 +27,7 @@ class ID3Processor:
         file_path: Path,
         genre: Optional[str] = None,
         year: Optional[str] = None,
-    ) -> Optional[ProcessingResult]:
+    ) -> ProcessingResult:
         """Process a single MP3 file to add missing tags.
         
         Args:
@@ -48,17 +48,24 @@ class ID3Processor:
             
             tags_to_add = []
 
-            if genre and self.needs_genre_tag(audio_file):
+            final_genre = genre or self.config.default_genre
+            final_year = year or self.config.default_year
+
+            if self.needs_genre_tag(audio_file):
                 tags_to_add.append("genre")
 
-            if year and self.needs_year_tag(audio_file):
+            if self.needs_year_tag(audio_file):
                 tags_to_add.append("year")
 
             if not tags_to_add:
-                return None
+                return ProcessingResult(
+                    file_path=file_path,
+                    success=True,
+                    tags_added=[],
+                )
 
             added_tags = self.add_missing_tags(
-                audio_file, file_path, genre, year
+                audio_file, file_path, final_genre, final_year
             )
 
             return ProcessingResult(

--- a/tests/test_musicbrainz_client.py
+++ b/tests/test_musicbrainz_client.py
@@ -30,5 +30,21 @@ class TestMusicBrainzClient(unittest.TestCase):
         metadata = client.get_genre('A', 'B', 'C')
         self.assertIsNone(metadata)
 
+    @patch('mp3_id3_processor.musicbrainz_client.musicbrainzngs.search_recordings')
+    def test_get_metadata_genre_and_year(self, mock_search):
+        mock_search.return_value = {
+            'recording-list': [
+                {
+                    'tag-list': [{'name': 'Jazz', 'count': '1'}],
+                    'release-list': [{'date': '2001-05-20'}]
+                }
+            ]
+        }
+        client = MusicBrainzClient()
+        metadata = client.get_metadata('Artist', 'Album', 'Track')
+        self.assertIsInstance(metadata, MusicBrainzMetadata)
+        self.assertEqual(metadata.genre, 'Jazz')
+        self.assertEqual(metadata.year, '2001')
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -260,7 +260,8 @@ class TestID3Processor:
         
         result = processor.process_file(test_file)
 
-        assert result is None
+        assert isinstance(result, ProcessingResult)
+        assert result.tags_added == []
         mock_add_tags.assert_not_called()
     
     @patch.object(ID3Processor, 'add_missing_tags')


### PR DESCRIPTION
## Summary
- integrate year fetching from MusicBrainz
- limit client requests per MusicBrainz guidelines
- tag tracks with genre and year when available
- update documentation to mention year tagging
- update tests for new metadata behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885e2b670508323a1c5fb3ed8a40c41