### PR TITLE
Add missing tag reporting and scan flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ mp3-id3-processor --config config.json --verbose
 | `--config`, `-c` | Path to configuration file (JSON format) |
 | `--verbose`, `-v` | Enable verbose output showing detailed progress |
 | `--dry-run` | Show what would be done without making any changes |
+| `--report-missing` | With `--dry-run`, report files missing genre or year |
 | `--help`, `-h` | Show help message and exit |
 
 ## Configuration

--- a/USAGE.md
+++ b/USAGE.md
@@ -137,6 +137,7 @@ Processing completed successfully!
 |--------|---------|---------|
 | `--directory` | Specify music directory | `--directory /media/music` |
 | `--dry-run` | Preview changes only | `--dry-run` |
+| `--report-missing` | Report files missing genre/year (use with `--dry-run`) | `--dry-run --report-missing` |
 | `--verbose` | Show detailed output | `--verbose` |
 | `--no-api` | Disable internet lookups | `--no-api` |
 | `--config` | Use config file | `--config my-settings.json` |

--- a/mp3_id3_processor/logger.py
+++ b/mp3_id3_processor/logger.py
@@ -96,7 +96,12 @@ class ProcessingLogger:
                     print(f"  {error_result.file_path.name}: {error_result.error_message}")
         else:
             print(f"\nNo errors encountered")
-        
+
+        if results.missing_tags:
+            print("\nFiles still missing tags:")
+            for path, tags in results.missing_tags.items():
+                print(f"  {path.name}: missing {', '.join(tags)}")
+
         print("=" * 50)
     
     def log_progress_update(self, current: int, total: int, file_name: Optional[str] = None):

--- a/mp3_id3_processor/models.py
+++ b/mp3_id3_processor/models.py
@@ -37,6 +37,7 @@ class ProcessingResults:
     files_modified: int = 0
     errors: List[ProcessingResult] = field(default_factory=list)
     tags_added_count: Dict[str, int] = field(default_factory=dict)
+    missing_tags: Dict[Path, List[str]] = field(default_factory=dict)
 
     def __post_init__(self):
         """Validate the ProcessingResults after initialization."""
@@ -78,6 +79,11 @@ class ProcessingResults:
                     self.tags_added_count[tag] = self.tags_added_count.get(tag, 0) + 1
         else:
             self.errors.append(result)
+
+    def add_missing(self, file_path: Path, tags: List[str]):
+        """Record tags that were still missing after processing."""
+        if tags:
+            self.missing_tags[file_path] = tags
 
     @property
     def success_rate(self) -> float:


### PR DESCRIPTION
## Summary
- add `--report-missing` flag and implement scanning mode
- track missing tags in `ProcessingResults`
- show missing tag info in summary logger output
- update MusicBrainz client to avoid extra lookups
- ensure `process_file` always returns a result
- document new option in README and USAGE

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885fbb8eb948323896e08ec60bc5ab3